### PR TITLE
omit empty trailing columns; omit empty rows

### DIFF
--- a/ods2md.py
+++ b/ods2md.py
@@ -34,9 +34,24 @@ def main(odf_path):
         print('##', sheet.name)
 
         column_widths = [max(display_len(display_text(cell)) for cell in column) for column in sheet.columns()]
+        # begin omit empty trailing columns (part 1 of 2)
+        while column_widths[-1] == 0:
+            column_widths.pop()
+        # end omit empty trailing columns (part 1 of 2)
 
         for n, row in enumerate(sheet.rows()):
+            # begin omit empty rows
+            row_content = ''
+            for m, cell in enumerate(row):
+                content = display_text(cell)
+                row_content += content
+            if row_content == '':
+                continue
+            # end omit empty rows
             print('|', end=' ')
+            # begin omit empty trailing columns (part 2 of 2)
+            del row[len(column_widths):]
+            # end omit empty trailing columns (part 2 of 2)
             for m, cell in enumerate(row):
                 content = display_text(cell)
                 disp_len = column_widths[m] + len(content) - display_len(content)


### PR DESCRIPTION
Added code to automatically omit empty trailing columns (intentionally right side only), and omit empty rows (any empty row). Without these modifications, requisites for [GFM tables](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#tables) were not fulfilled.

Has been used to convert [this ods](https://github.com/roboticslab-uc3m/teo-main/blob/ba00e3a23876aa09d4ad4619b507ae0af8ac8421/doc/fig/src/DH%20parameters.ods) into [this md](https://github.com/roboticslab-uc3m/teo-main/blob/ba00e3a23876aa09d4ad4619b507ae0af8ac8421/doc/fig/DH%20parameters.md) with success.

